### PR TITLE
Implement Pod Logs and Event Listing functionality

### DIFF
--- a/cmd/mcp-k8s/main.go
+++ b/cmd/mcp-k8s/main.go
@@ -117,6 +117,11 @@ func runServer(cmd *cobra.Command, args []string) {
 		s.AddTool(tools.CreateListResourcesTool(), tools.HandleListResources(client))
 	}
 
+	// Add operational tools (always enabled for read operations)
+	fmt.Println("Registering operational tools...")
+	s.AddTool(tools.CreateGetPodLogsTool(), tools.HandleGetPodLogs(client))
+	s.AddTool(tools.CreateListEventsTool(), tools.HandleListEvents(client))
+
 	// Add write operation tools (if enabled)
 	if cfg.EnableCreate {
 		fmt.Println("Registering resource creation tool...")

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/spf13/cobra v1.10.2
 	helm.sh/helm/v3 v3.18.5
+	k8s.io/api v0.33.3
 	k8s.io/apimachinery v0.33.3
 	k8s.io/client-go v0.33.3
 	sigs.k8s.io/yaml v1.5.0
@@ -110,7 +111,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.33.3 // indirect
 	k8s.io/apiextensions-apiserver v0.33.3 // indirect
 	k8s.io/apiserver v0.33.3 // indirect
 	k8s.io/cli-runtime v0.33.3 // indirect

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -321,10 +321,6 @@ func (c *Client) GetKubeconfigPath() string {
 
 // GetPodLogs retrieves logs from a specific pod
 func (c *Client) GetPodLogs(ctx context.Context, namespace, podName, container string, tailLines int) (string, error) {
-	if namespace == "" {
-		namespace = DefaultNamespace
-	}
-
 	opts := &corev1.PodLogOptions{
 		TailLines: int64Ptr(int64(tailLines)),
 	}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -15,6 +17,13 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
+)
+
+const (
+	// DefaultNamespace is the default Kubernetes namespace
+	DefaultNamespace = "default"
+	// DefaultPodLogTailLines is the default number of lines to retrieve from pod logs
+	DefaultPodLogTailLines = 50
 )
 
 // Client wraps Kubernetes client functionality
@@ -308,4 +317,98 @@ func (c *Client) findGroupVersionResource(kind string) (*schema.GroupVersionReso
 // GetKubeconfigPath returns the kubeconfig path used by the client
 func (c *Client) GetKubeconfigPath() string {
 	return c.kubeconfigPath
+}
+
+// GetPodLogs retrieves logs from a specific pod
+func (c *Client) GetPodLogs(ctx context.Context, namespace, podName, container string, tailLines int) (string, error) {
+	if namespace == "" {
+		namespace = DefaultNamespace
+	}
+
+	opts := &corev1.PodLogOptions{
+		TailLines: int64Ptr(int64(tailLines)),
+	}
+	if container != "" {
+		opts.Container = container
+	}
+
+	req := c.clientset.CoreV1().Pods(namespace).GetLogs(podName, opts)
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get pod logs: %w", err)
+	}
+	defer stream.Close()
+
+	logs, err := io.ReadAll(stream)
+	if err != nil {
+		return "", fmt.Errorf("failed to read logs: %w", err)
+	}
+
+	return string(logs), nil
+}
+
+// ListEvents lists events within a namespace or for a specific resource
+func (c *Client) ListEvents(ctx context.Context, namespace, kind, name, fieldSelector string) ([]map[string]interface{}, error) {
+	opts := metav1.ListOptions{}
+	if fieldSelector != "" {
+		opts.FieldSelector = fieldSelector
+	}
+
+	// If kind and name are specified, add field selector for the involved object
+	if kind != "" && name != "" {
+		fieldSelectorValue := fmt.Sprintf("involvedObject.kind=%s,involvedObject.name=%s", kind, name)
+		if opts.FieldSelector != "" {
+			opts.FieldSelector = opts.FieldSelector + "," + fieldSelectorValue
+		} else {
+			opts.FieldSelector = fieldSelectorValue
+		}
+	}
+
+	var events *corev1.EventList
+	var err error
+
+	if namespace != "" {
+		events, err = c.clientset.CoreV1().Events(namespace).List(ctx, opts)
+	} else {
+		// List events from all namespaces
+		events, err = c.clientset.CoreV1().Events("").List(ctx, opts)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to list events: %w", err)
+	}
+
+	result := make([]map[string]interface{}, 0, len(events.Items))
+	for _, event := range events.Items {
+		result = append(result, map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":              event.Name,
+				"namespace":         event.Namespace,
+				"creationTimestamp": event.CreationTimestamp,
+			},
+			"involvedObject": map[string]interface{}{
+				"kind":      event.InvolvedObject.Kind,
+				"name":      event.InvolvedObject.Name,
+				"namespace": event.InvolvedObject.Namespace,
+				"uid":       event.InvolvedObject.UID,
+			},
+			"reason":         event.Reason,
+			"message":        event.Message,
+			"type":           event.Type,
+			"firstTimestamp": event.FirstTimestamp,
+			"lastTimestamp":  event.LastTimestamp,
+			"count":          event.Count,
+			"source": map[string]interface{}{
+				"component": event.Source.Component,
+				"host":      event.Source.Host,
+			},
+		})
+	}
+
+	return result, nil
+}
+
+// int64Ptr returns a pointer to an int64
+func int64Ptr(i int64) *int64 {
+	return &i
 }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
@@ -333,7 +334,12 @@ func (c *Client) GetPodLogs(ctx context.Context, namespace, podName, container s
 	if err != nil {
 		return "", fmt.Errorf("failed to get pod logs: %w", err)
 	}
-	defer stream.Close()
+	defer func(stream io.ReadCloser) {
+		err := stream.Close()
+		if err != nil {
+			log.Printf("failed to close pod logs stream: %v", err)
+		}
+	}(stream)
 
 	logs, err := io.ReadAll(stream)
 	if err != nil {

--- a/internal/k8s/helm.go
+++ b/internal/k8s/helm.go
@@ -55,7 +55,7 @@ func NewHelmClient(namespace string, kubeconfigPath string) (*HelmClient, error)
 	if namespace != "" {
 		settings.SetNamespace(namespace)
 	} else {
-		settings.SetNamespace("default")
+		settings.SetNamespace(DefaultNamespace)
 	}
 
 	actionConfig := new(action.Configuration)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -322,14 +322,11 @@ func HandleGetPodLogs(client *k8s.Client) func(ctx context.Context, request mcp.
 		// Parse tail_lines as string and convert to int
 		tailLinesStr := request.GetString("tail_lines", DefaultPodLogTailLinesStr)
 		tailLines := k8s.DefaultPodLogTailLines
-		if tailLinesStr != "" {
-			parsed, err := strconv.Atoi(tailLinesStr)
-			if err != nil {
-				return nil, fmt.Errorf("invalid tail_lines value: %s, must be a number", tailLinesStr)
-			}
-			tailLines = parsed
+		parsed, err := strconv.Atoi(tailLinesStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid tail_lines value: %s, must be a number", tailLinesStr)
 		}
-
+		tailLines = parsed
 		logs, err := client.GetPodLogs(ctx, namespace, podName, container, tailLines)
 		if err != nil {
 			return nil, err

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -321,12 +321,10 @@ func HandleGetPodLogs(client *k8s.Client) func(ctx context.Context, request mcp.
 
 		// Parse tail_lines as string and convert to int
 		tailLinesStr := request.GetString("tail_lines", DefaultPodLogTailLinesStr)
-		tailLines := k8s.DefaultPodLogTailLines
-		parsed, err := strconv.Atoi(tailLinesStr)
+		tailLines, err := strconv.Atoi(tailLinesStr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid tail_lines value: %s, must be a number", tailLinesStr)
 		}
-		tailLines = parsed
 		logs, err := client.GetPodLogs(ctx, namespace, podName, container, tailLines)
 		if err != nil {
 			return nil, err

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -4,9 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/silenceper/mcp-k8s/internal/k8s"
+)
+
+const (
+	// DefaultPodLogTailLinesStr is the default number of lines to retrieve from pod logs as string
+	DefaultPodLogTailLinesStr = "50"
 )
 
 // CreateGetAPIResourcesTool creates a tool for getting API resources
@@ -279,5 +285,97 @@ func HandleDeleteResource(client *k8s.Client) func(ctx context.Context, request 
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Successfully deleted resource %s/%s", kind, name)), nil
+	}
+}
+
+// CreateGetPodLogsTool creates a tool for getting pod logs
+func CreateGetPodLogsTool() mcp.Tool {
+	return mcp.NewTool("get_pod_logs",
+		mcp.WithDescription("Retrieve logs from a specific pod"),
+		mcp.WithString("pod_name",
+			mcp.Required(),
+			mcp.Description("Pod name"),
+		),
+		mcp.WithString("namespace",
+			mcp.Description(fmt.Sprintf("Namespace (default: %s)", k8s.DefaultNamespace)),
+		),
+		mcp.WithString("container",
+			mcp.Description("Container name (optional, gets all containers if not specified)"),
+		),
+		mcp.WithString("tail_lines",
+			mcp.Description(fmt.Sprintf("Number of lines to retrieve from the end of logs (optional, default: %d)", k8s.DefaultPodLogTailLines)),
+		),
+	)
+}
+
+// HandleGetPodLogs handles the get pod logs tool
+func HandleGetPodLogs(client *k8s.Client) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		podName, err := request.RequireString("pod_name")
+		if err != nil {
+			return nil, fmt.Errorf("missing required parameter: pod_name: %w", err)
+		}
+
+		namespace := request.GetString("namespace", k8s.DefaultNamespace)
+		container := request.GetString("container", "")
+
+		// Parse tail_lines as string and convert to int
+		tailLinesStr := request.GetString("tail_lines", DefaultPodLogTailLinesStr)
+		tailLines := k8s.DefaultPodLogTailLines
+		if tailLinesStr != "" {
+			parsed, err := strconv.Atoi(tailLinesStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid tail_lines value: %s, must be a number", tailLinesStr)
+			}
+			tailLines = parsed
+		}
+
+		logs, err := client.GetPodLogs(ctx, namespace, podName, container, tailLines)
+		if err != nil {
+			return nil, err
+		}
+
+		return mcp.NewToolResultText(logs), nil
+	}
+}
+
+// CreateListEventsTool creates a tool for listing events
+func CreateListEventsTool() mcp.Tool {
+	return mcp.NewTool("list_events",
+		mcp.WithDescription("List events within a namespace or for a specific resource"),
+		mcp.WithString("namespace",
+			mcp.Description("Namespace to list events from (if not specified, lists from all namespaces)"),
+		),
+		mcp.WithString("kind",
+			mcp.Description("Resource kind to filter events (e.g., Pod, Deployment)"),
+		),
+		mcp.WithString("name",
+			mcp.Description("Resource name to filter events"),
+		),
+		mcp.WithString("field_selector",
+			mcp.Description("Field selector to filter events (format: key1=value1,key2=value2)"),
+		),
+	)
+}
+
+// HandleListEvents handles the list events tool
+func HandleListEvents(client *k8s.Client) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		namespace := request.GetString("namespace", "")
+		kind := request.GetString("kind", "")
+		name := request.GetString("name", "")
+		fieldSelector := request.GetString("field_selector", "")
+
+		events, err := client.ListEvents(ctx, namespace, kind, name, fieldSelector)
+		if err != nil {
+			return nil, err
+		}
+
+		jsonResponse, err := json.Marshal(events)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize response: %w", err)
+		}
+
+		return mcp.NewToolResultText(string(jsonResponse)), nil
 	}
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -300,7 +300,7 @@ func CreateGetPodLogsTool() mcp.Tool {
 			mcp.Description(fmt.Sprintf("Namespace (default: %s)", k8s.DefaultNamespace)),
 		),
 		mcp.WithString("container",
-			mcp.Description("Container name (optional, gets all containers if not specified)"),
+			mcp.Description("Container name (optional, defaults to first container in multi-container pods)"),
 		),
 		mcp.WithString("tail_lines",
 			mcp.Description(fmt.Sprintf("Number of lines to retrieve from the end of logs (optional, default: %d)", k8s.DefaultPodLogTailLines)),


### PR DESCRIPTION
## Description

This PR adds two essential operational tools to the mcp-k8s server: Pod Logs retrieval and Event Listing functionality. These tools are critical for troubleshooting and diagnosing issues in Kubernetes clusters.

## New Features

### 1. Pod Logs Tool (`get_pod_logs`)
- Retrieve logs from specific pods
- Support for specifying container name (useful for multi-container pods)
- Configurable tail lines (default: 50 lines)
- Support for namespace specification (default: default)

**Parameters:**
- `pod_name` (required): Pod name
- `namespace` (optional): Namespace (default: default)
- `container` (optional): Container name
- `tail_lines` (optional): Number of lines to retrieve (default: 50)

### 2. Event Listing Tool (`list_events`)
- List events within a namespace or for specific resources
- Support for filtering by resource kind and name
- Support for custom field selectors
- Can list events from all namespaces if namespace is not specified

**Parameters:**
- `namespace` (optional): Namespace to list events from
- `kind` (optional): Resource kind to filter events
- `name` (optional): Resource name to filter events
- `field_selector` (optional): Custom field selector

## Code Improvements

- Eliminated magic numbers/strings: Replaced hardcoded values with constants
  - `DefaultNamespace = "default"`
  - `DefaultPodLogTailLines = 50`
- Consistent namespace handling across the codebase
- Better code maintainability with centralized default values

## Files Changed

- `internal/k8s/client.go`: Added `GetPodLogs()` and `ListEvents()` methods
- `internal/tools/tools.go`: Added tool definitions and handlers
- `cmd/mcp-k8s/main.go`: Registered new tools in the MCP server
- `internal/k8s/helm.go`: Updated to use `DefaultNamespace` constant

## Usage Examples

**Get Pod Logs:**
{
  "tool": "get_pod_logs",
  "arguments": {
    "pod_name": "nginx-deployment-xxx",
    "namespace": "default",
    "tail_lines": "50"
  }
}**List Events:**n
{
  "tool": "list_events",
  "arguments": {
    "namespace": "default",
    "kind": "Pod",
    "name": "nginx-deployment-xxx"
  }
}## Related

Addresses Phase 1 requirements from the project roadmap:
- ✅ Pod Logs functionality
- ✅ Event Listing functionality

## Breaking Changes

None. This is a pure feature addition.